### PR TITLE
Add `cursor-pointer` class to save button on dashboard

### DIFF
--- a/web/src/components/Dashboard/RewardForms/BttvForm.tsx
+++ b/web/src/components/Dashboard/RewardForms/BttvForm.tsx
@@ -97,7 +97,7 @@ export function BttvForm({ userConfig, setUserConfig, fetchConfig }: { userConfi
                     <input defaultChecked={userConfig.Rewards.Bttv?.enabled} type="checkbox" {...register("enabled")} className="form-checkbox rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-offset-0 focus:ring-indigo-200 focus:ring-opacity-50" />
                     <span className="ml-2">Enabled</span>
                 </label>
-                <input type="submit" className="bg-green-700 hover:bg-green-600 p-2 rounded shadow block mt-3" value="save" />
+                <input type="submit" className="bg-green-700 hover:bg-green-600 p-2 rounded shadow block mt-3 cursor-pointer" value="save" />
             </div>
         </form>
     );


### PR DESCRIPTION
When hovering over the 'save' button in the BetterTTV Emote dashboard on https://bitraft.gempir.com/dashboard the cursor does not turn into a pointer, while it does when hovering over the Delete button.

This PR fixes that issue.
